### PR TITLE
Suitable grub update method

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,12 @@ done < /dev/tty
 GRUB_DIR='grub'
 UPDATE_GRUB=''
 
+# Detect bootloader
+if [ -d "/boot/efi" ]; then
+    echo "The current bootloader is UEFI"
+    UEFI_MODE=YES
+fi
+
 if [ -e /etc/os-release ]; then
 
     source /etc/os-release
@@ -59,7 +65,11 @@ if [ -e /etc/os-release ]; then
             "$ID_LIKE" =~ (fedora|rhel|suse) ]]; then
 
         GRUB_DIR='grub2'
-        UPDATE_GRUB='grub2-mkconfig -o /boot/grub2/grub.cfg'
+        if [ "$UEFI_MODE" == "YES" ]; then
+             UPDATE_GRUB='grub2-mkconfig -o /boot/efi/EFI/$ID/grub.cfg'
+        else
+             UPDATE_GRUB='grub2-mkconfig -o /boot/grub2/grub.cfg'
+        fi
     fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ if [ -e /etc/os-release ]; then
 
         GRUB_DIR='grub2'
         if [ "$UEFI_MODE" == "YES" ]; then
-             UPDATE_GRUB='grub2-mkconfig -o /boot/efi/EFI/$ID/grub.cfg'
+             UPDATE_GRUB="grub2-mkconfig -o /boot/efi/EFI/$ID/grub.cfg"
         else
              UPDATE_GRUB='grub2-mkconfig -o /boot/grub2/grub.cfg'
         fi


### PR DESCRIPTION
    ** **
    Use UEFI to start, the default grub.cfg is in '/boot/efi/efi/$ID/',
    add a judgment to select the appropriate update method.
    ** **

    ** **
    This modification applies to redhat and it's modified version.
    ** **

Signed-off-by: 弱弱的胖橘猫丷 <gesangtome@foxmail.com>